### PR TITLE
Sensor status is now correctly updated when setting new address

### DIFF
--- a/src/Adafruit_VL53L0X.cpp
+++ b/src/Adafruit_VL53L0X.cpp
@@ -141,7 +141,7 @@ boolean Adafruit_VL53L0X::begin(uint8_t i2c_addr, boolean debug ) {
 boolean Adafruit_VL53L0X::setAddress(uint8_t newAddr) {
   newAddr &= 0x7F;
 
-  VL53L0X_SetDeviceAddress(pMyDevice, newAddr * 2); // 7->8 bit
+  Status = VL53L0X_SetDeviceAddress(pMyDevice, newAddr * 2); // 7->8 bit
 
   delay(10);
 


### PR DESCRIPTION
Sensor status (VL53L0X_Error) was not being updating while updating I2C address, and so errors are never caught, with the I2C bus or otherwise. This may cause the sensor to stop functioning (even when the user fixes any hardware/connection issues with I2C) because the VL53L0X_Dev_t structure was updated with the address (which wasn't ever updated).