### PR TITLE
Fix possible UR, clear compile warnings, add printPalErrorString() wrapper

### DIFF
--- a/src/Adafruit_VL53L0X.cpp
+++ b/src/Adafruit_VL53L0X.cpp
@@ -686,6 +686,24 @@ void Adafruit_VL53L0X::printRangeStatus(
 
 /**************************************************************************/
 /*!
+    @brief  Print a PAL error code out via Serial.print in a human-readable
+           format
+    @param PalErrorCode the error code to print
+*/
+/**************************************************************************/
+void Adafruit_VL53L0X::printPalErrorString(VL53L0X_Error PalErrorCode) {
+  char buf[VL53L0X_MAX_STRING_LENGTH];
+
+  VL53L0X_GetPalErrorString(PalErrorCode, buf);
+
+  Serial.print(F("PalErrorCode: "));
+  Serial.print(PalErrorCode);
+  Serial.print(F(" : "));
+  Serial.println(buf);
+}
+
+/**************************************************************************/
+/*!
     @brief  Single shot ranging. Be sure to check the return of readRangeStatus
     to before using the return value!
     @return Distance in millimeters if valid

--- a/src/Adafruit_VL53L0X.h
+++ b/src/Adafruit_VL53L0X.h
@@ -77,6 +77,7 @@ public:
       boolean debug = false);
   void
   printRangeStatus(VL53L0X_RangingMeasurementData_t *pRangingMeasurementData);
+  void printPalErrorString(VL53L0X_Error PalErrorCode);
 
   VL53L0X_Error getRangingMeasurement(
       VL53L0X_RangingMeasurementData_t *pRangingMeasurementData,

--- a/src/core/src/vl53l0x_api.cpp
+++ b/src/core/src/vl53l0x_api.cpp
@@ -2010,8 +2010,8 @@ VL53L0X_PerformOffsetCalibration(VL53L0X_DEV Dev,
 VL53L0X_Error VL53L0X_CheckAndLoadInterruptSettings(VL53L0X_DEV Dev,
                                                     uint8_t StartNotStopFlag) {
   uint8_t InterruptConfig;
-  FixPoint1616_t ThresholdLow;
-  FixPoint1616_t ThresholdHigh;
+  FixPoint1616_t ThresholdLow = 0;  // both zero-initialized as they might
+  FixPoint1616_t ThresholdHigh = 0; // not get set by _GetInterruptThresholds()
   VL53L0X_Error Status = VL53L0X_ERROR_NONE;
 
   InterruptConfig =


### PR DESCRIPTION
I improved the library regarding following points:

- Fix a possible undefined read error in VL53L0X_CheckAndLoadInterruptSettings().
- Clean library from compiler warnings by removing unused variables.
- Add Adafruit_VL53L0X::printPalErrorString() to human-readably print the status code returned e.g. by Adafruit_VL53L0X::getSingleRangingMeasurement().

Thanks for maintaining and merging :-)