### PR TITLE
Fixed relative paths.

### DIFF
--- a/src/core/src/vl53l0x_api.cpp
+++ b/src/core/src/vl53l0x_api.cpp
@@ -28,12 +28,12 @@
 
 #define USE_I2C_2V8
 
-#include "vl53l0x_api.h"
-#include "vl53l0x_tuning.h"
-#include "vl53l0x_interrupt_threshold_settings.h"
-#include "vl53l0x_api_core.h"
-#include "vl53l0x_api_calibration.h"
-#include "vl53l0x_api_strings.h"
+#include "../../vl53l0x_api.h"
+#include "../../vl53l0x_tuning.h"
+#include "../../vl53l0x_interrupt_threshold_settings.h"
+#include "../../vl53l0x_api_core.h"
+#include "../../vl53l0x_api_calibration.h"
+#include "../../vl53l0x_api_strings.h"
 
 #ifndef __KERNEL__
 #include <stdlib.h>

--- a/src/core/src/vl53l0x_api_calibration.cpp
+++ b/src/core/src/vl53l0x_api_calibration.cpp
@@ -26,9 +26,9 @@
  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 
-#include "vl53l0x_api.h"
-#include "vl53l0x_api_core.h"
-#include "vl53l0x_api_calibration.h"
+#include "../../vl53l0x_api.h"
+#include "../../vl53l0x_api_core.h"
+#include "../../vl53l0x_api_calibration.h"
 
 #ifndef __KERNEL__
 #include <stdlib.h>

--- a/src/core/src/vl53l0x_api_core.cpp
+++ b/src/core/src/vl53l0x_api_core.cpp
@@ -26,9 +26,9 @@
  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 
-#include "vl53l0x_api.h"
-#include "vl53l0x_api_core.h"
-#include "vl53l0x_api_calibration.h"
+#include "../../vl53l0x_api.h"
+#include "../../vl53l0x_api_core.h"
+#include "../../vl53l0x_api_calibration.h"
 
 
 #ifndef __KERNEL__

--- a/src/core/src/vl53l0x_api_ranging.cpp
+++ b/src/core/src/vl53l0x_api_ranging.cpp
@@ -26,8 +26,8 @@
  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 
-#include "vl53l0x_api.h"
-#include "vl53l0x_api_core.h"
+#include "../../vl53l0x_api.h"
+#include "../../vl53l0x_api_core.h"
 
 
 #ifndef __KERNEL__

--- a/src/core/src/vl53l0x_api_strings.cpp
+++ b/src/core/src/vl53l0x_api_strings.cpp
@@ -26,9 +26,9 @@
  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 
-#include "vl53l0x_api.h"
-#include "vl53l0x_api_core.h"
-#include "vl53l0x_api_strings.h"
+#include "../../vl53l0x_api.h"
+#include "../../vl53l0x_api_core.h"
+#include "../../vl53l0x_api_strings.h"
 
 #ifndef __KERNEL__
 #include <stdlib.h>

--- a/src/platform/src/vl53l0x_i2c_comms.cpp
+++ b/src/platform/src/vl53l0x_i2c_comms.cpp
@@ -1,5 +1,5 @@
-#include "vl53l0x_i2c_platform.h"
-#include "vl53l0x_def.h"
+#include "../../vl53l0x_i2c_platform.h"
+#include "../../vl53l0x_def.h"
 
 //#define I2C_DEBUG
 

--- a/src/platform/src/vl53l0x_platform.cpp
+++ b/src/platform/src/vl53l0x_platform.cpp
@@ -34,9 +34,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * provide variable word size byte/Word/dword VL6180x register access via i2c
  *
  */
-#include "vl53l0x_platform.h"
-#include "vl53l0x_i2c_platform.h"
-#include "vl53l0x_api.h"
+#include "../../vl53l0x_platform.h"
+#include "../../vl53l0x_i2c_platform.h"
+#include "../../vl53l0x_api.h"
 
 #define LOG_FUNCTION_START(fmt, ... )           _LOG_FUNCTION_START(TRACE_MODULE_PLATFORM, fmt, ##__VA_ARGS__)
 #define LOG_FUNCTION_END(status, ... )          _LOG_FUNCTION_END(TRACE_MODULE_PLATFORM, status, ##__VA_ARGS__)


### PR DESCRIPTION
Problem: If one attempts to use this library as a part of another Arduino library, the sketch will not compile.
Reason: The source files in the \core and \platform contain header includes that do not have a path included, they point to header files within the same directory.
Solution: Add "../../" to header includes in \core and \platform, or,