### PR TITLE
Add support for specifying an alternate I2C bus other than "Wire"

### DIFF
--- a/src/Adafruit_VL53L0X.cpp
+++ b/src/Adafruit_VL53L0X.cpp
@@ -46,7 +46,7 @@
     @returns True if device is set up, false on any failure
 */
 /**************************************************************************/
-boolean Adafruit_VL53L0X::begin(uint8_t i2c_addr, boolean debug ) {
+boolean Adafruit_VL53L0X::begin(uint8_t i2c_addr, boolean debug, TwoWire *i2c) {
   int32_t   status_int;
   int32_t   init_done         = 0;
 
@@ -59,8 +59,9 @@ boolean Adafruit_VL53L0X::begin(uint8_t i2c_addr, boolean debug ) {
   pMyDevice->I2cDevAddr      =  VL53L0X_I2C_ADDR;  // default
   pMyDevice->comms_type      =  1;
   pMyDevice->comms_speed_khz =  400;
+  pMyDevice->i2c = i2c;
 
-  Wire.begin();     // VL53L0X_i2c_init();
+  pMyDevice->i2c->begin();     // VL53L0X_i2c_init();
 
   // unclear if this is even needed:
   if( VL53L0X_IMPLEMENTATION_VER_MAJOR != VERSION_REQUIRED_MAJOR ||

--- a/src/Adafruit_VL53L0X.cpp
+++ b/src/Adafruit_VL53L0X.cpp
@@ -43,6 +43,7 @@
     @brief  Setups the I2C interface and hardware
     @param  i2c_addr Optional I2C address the sensor can be found on. Default is 0x29
     @param debug Optional debug flag. If true, debug information will print out via Serial.print during setup. Defaults to false.
+    @param  i2c Optional I2C bus the sensor is located on. Default is Wire
     @returns True if device is set up, false on any failure
 */
 /**************************************************************************/

--- a/src/Adafruit_VL53L0X.h
+++ b/src/Adafruit_VL53L0X.h
@@ -38,7 +38,7 @@
 class Adafruit_VL53L0X
 {
   public:
-    boolean       begin(uint8_t i2c_addr = VL53L0X_I2C_ADDR, boolean debug = false );
+    boolean       begin(uint8_t i2c_addr = VL53L0X_I2C_ADDR, boolean debug = false, TwoWire *i2c = &Wire);
     boolean       setAddress(uint8_t newAddr);
 
     /**************************************************************************/

--- a/src/platform/src/vl53l0x_i2c_comms.cpp
+++ b/src/platform/src/vl53l0x_i2c_comms.cpp
@@ -3,19 +3,19 @@
 
 //#define I2C_DEBUG
 
-int VL53L0X_i2c_init(void) {
-  Wire.begin();
+int VL53L0X_i2c_init(TwoWire *i2c) {
+  i2c->begin();
   return VL53L0X_ERROR_NONE;
 }
 
-int VL53L0X_write_multi(uint8_t deviceAddress, uint8_t index, uint8_t *pdata, uint32_t count) {
-  Wire.beginTransmission(deviceAddress);
-  Wire.write(index);
+int VL53L0X_write_multi(uint8_t deviceAddress, uint8_t index, uint8_t *pdata, uint32_t count, TwoWire *i2c) {
+  i2c->beginTransmission(deviceAddress);
+  i2c->write(index);
 #ifdef I2C_DEBUG
   Serial.print("\tWriting "); Serial.print(count); Serial.print(" to addr 0x"); Serial.print(index, HEX); Serial.print(": ");
 #endif
   while(count--) {
-    Wire.write((uint8_t)pdata[0]);
+    i2c->write((uint8_t)pdata[0]);
 #ifdef I2C_DEBUG
     Serial.print("0x"); Serial.print(pdata[0], HEX); Serial.print(", ");
 #endif
@@ -24,21 +24,21 @@ int VL53L0X_write_multi(uint8_t deviceAddress, uint8_t index, uint8_t *pdata, ui
 #ifdef I2C_DEBUG
   Serial.println();
 #endif
-  Wire.endTransmission();
+  i2c->endTransmission();
   return VL53L0X_ERROR_NONE;
 }
 
-int VL53L0X_read_multi(uint8_t deviceAddress, uint8_t index, uint8_t *pdata, uint32_t count) {
-  Wire.beginTransmission(deviceAddress);
-  Wire.write(index);
-  Wire.endTransmission();
-  Wire.requestFrom(deviceAddress, (byte)count);
+int VL53L0X_read_multi(uint8_t deviceAddress, uint8_t index, uint8_t *pdata, uint32_t count, TwoWire *i2c) {
+  i2c->beginTransmission(deviceAddress);
+  i2c->write(index);
+  i2c->endTransmission();
+  i2c->requestFrom(deviceAddress, (byte)count);
 #ifdef I2C_DEBUG
   Serial.print("\tReading "); Serial.print(count); Serial.print(" from addr 0x"); Serial.print(index, HEX); Serial.print(": ");
 #endif
 
   while (count--) {
-    pdata[0] = Wire.read();
+    pdata[0] = i2c->read();
 #ifdef I2C_DEBUG
     Serial.print("0x"); Serial.print(pdata[0], HEX); Serial.print(", ");
 #endif
@@ -50,18 +50,18 @@ int VL53L0X_read_multi(uint8_t deviceAddress, uint8_t index, uint8_t *pdata, uin
   return VL53L0X_ERROR_NONE;
 }
 
-int VL53L0X_write_byte(uint8_t deviceAddress, uint8_t index, uint8_t data) {
-  return VL53L0X_write_multi(deviceAddress, index, &data, 1);
+int VL53L0X_write_byte(uint8_t deviceAddress, uint8_t index, uint8_t data, TwoWire *i2c) {
+  return VL53L0X_write_multi(deviceAddress, index, &data, 1, i2c);
 }
 
-int VL53L0X_write_word(uint8_t deviceAddress, uint8_t index, uint16_t data) {
+int VL53L0X_write_word(uint8_t deviceAddress, uint8_t index, uint16_t data, TwoWire *i2c) {
   uint8_t buff[2];
   buff[1] = data & 0xFF;
   buff[0] = data >> 8;
-  return VL53L0X_write_multi(deviceAddress, index, buff, 2);
+  return VL53L0X_write_multi(deviceAddress, index, buff, 2, i2c);
 }
 
-int VL53L0X_write_dword(uint8_t deviceAddress, uint8_t index, uint32_t data) {
+int VL53L0X_write_dword(uint8_t deviceAddress, uint8_t index, uint32_t data, TwoWire *i2c) {
   uint8_t buff[4];
 
   buff[3] = data & 0xFF;
@@ -69,16 +69,16 @@ int VL53L0X_write_dword(uint8_t deviceAddress, uint8_t index, uint32_t data) {
   buff[1] = data >> 16;
   buff[0] = data >> 24;
 
-  return VL53L0X_write_multi(deviceAddress, index, buff, 4);
+  return VL53L0X_write_multi(deviceAddress, index, buff, 4, i2c);
 }
 
-int VL53L0X_read_byte(uint8_t deviceAddress, uint8_t index, uint8_t *data) {
-  return VL53L0X_read_multi(deviceAddress, index, data, 1);
+int VL53L0X_read_byte(uint8_t deviceAddress, uint8_t index, uint8_t *data, TwoWire *i2c) {
+  return VL53L0X_read_multi(deviceAddress, index, data, 1, i2c);
 }
 
-int VL53L0X_read_word(uint8_t deviceAddress, uint8_t index, uint16_t *data) {
+int VL53L0X_read_word(uint8_t deviceAddress, uint8_t index, uint16_t *data, TwoWire *i2c) {
   uint8_t buff[2];
-  int r = VL53L0X_read_multi(deviceAddress, index, buff, 2);
+  int r = VL53L0X_read_multi(deviceAddress, index, buff, 2, i2c);
 
   uint16_t tmp;
   tmp = buff[0];
@@ -89,9 +89,9 @@ int VL53L0X_read_word(uint8_t deviceAddress, uint8_t index, uint16_t *data) {
   return r;
 }
 
-int VL53L0X_read_dword(uint8_t deviceAddress, uint8_t index, uint32_t *data) {
+int VL53L0X_read_dword(uint8_t deviceAddress, uint8_t index, uint32_t *data, TwoWire *i2c) {
   uint8_t buff[4];
-  int r = VL53L0X_read_multi(deviceAddress, index, buff, 4);
+  int r = VL53L0X_read_multi(deviceAddress, index, buff, 4, i2c);
 
   uint32_t tmp;
   tmp = buff[0];

--- a/src/platform/src/vl53l0x_platform.cpp
+++ b/src/platform/src/vl53l0x_platform.cpp
@@ -113,7 +113,7 @@ VL53L0X_Error VL53L0X_WriteMulti(VL53L0X_DEV Dev, uint8_t index, uint8_t *pdata,
 
 	deviceAddress = Dev->I2cDevAddr;
 
-	status_int = VL53L0X_write_multi(deviceAddress, index, pdata, count);
+	status_int = VL53L0X_write_multi(deviceAddress, index, pdata, count, Dev->i2c);
 
 	if (status_int != 0)
 		Status = VL53L0X_ERROR_CONTROL_INTERFACE;
@@ -134,7 +134,7 @@ VL53L0X_Error VL53L0X_ReadMulti(VL53L0X_DEV Dev, uint8_t index, uint8_t *pdata, 
 
     deviceAddress = Dev->I2cDevAddr;
 
-	status_int = VL53L0X_read_multi(deviceAddress, index, pdata, count);
+	status_int = VL53L0X_read_multi(deviceAddress, index, pdata, count, Dev->i2c);
 
 	if (status_int != 0)
 		Status = VL53L0X_ERROR_CONTROL_INTERFACE;
@@ -150,7 +150,7 @@ VL53L0X_Error VL53L0X_WrByte(VL53L0X_DEV Dev, uint8_t index, uint8_t data){
 
     deviceAddress = Dev->I2cDevAddr;
 
-	status_int = VL53L0X_write_byte(deviceAddress, index, data);
+	status_int = VL53L0X_write_byte(deviceAddress, index, data, Dev->i2c);
 
 	if (status_int != 0)
 		Status = VL53L0X_ERROR_CONTROL_INTERFACE;
@@ -165,7 +165,7 @@ VL53L0X_Error VL53L0X_WrWord(VL53L0X_DEV Dev, uint8_t index, uint16_t data){
 
     deviceAddress = Dev->I2cDevAddr;
 
-	status_int = VL53L0X_write_word(deviceAddress, index, data);
+	status_int = VL53L0X_write_word(deviceAddress, index, data, Dev->i2c);
 
 	if (status_int != 0)
 		Status = VL53L0X_ERROR_CONTROL_INTERFACE;
@@ -180,7 +180,7 @@ VL53L0X_Error VL53L0X_WrDWord(VL53L0X_DEV Dev, uint8_t index, uint32_t data){
 
     deviceAddress = Dev->I2cDevAddr;
 
-	status_int = VL53L0X_write_dword(deviceAddress, index, data);
+	status_int = VL53L0X_write_dword(deviceAddress, index, data, Dev->i2c);
 
 	if (status_int != 0)
 		Status = VL53L0X_ERROR_CONTROL_INTERFACE;
@@ -196,14 +196,14 @@ VL53L0X_Error VL53L0X_UpdateByte(VL53L0X_DEV Dev, uint8_t index, uint8_t AndData
 
     deviceAddress = Dev->I2cDevAddr;
 
-    status_int = VL53L0X_read_byte(deviceAddress, index, &data);
+    status_int = VL53L0X_read_byte(deviceAddress, index, &data, Dev->i2c);
 
     if (status_int != 0)
         Status = VL53L0X_ERROR_CONTROL_INTERFACE;
 
     if (Status == VL53L0X_ERROR_NONE) {
         data = (data & AndData) | OrData;
-        status_int = VL53L0X_write_byte(deviceAddress, index, data);
+        status_int = VL53L0X_write_byte(deviceAddress, index, data, Dev->i2c);
 
         if (status_int != 0)
             Status = VL53L0X_ERROR_CONTROL_INTERFACE;
@@ -219,7 +219,7 @@ VL53L0X_Error VL53L0X_RdByte(VL53L0X_DEV Dev, uint8_t index, uint8_t *data){
 
     deviceAddress = Dev->I2cDevAddr;
 
-    status_int = VL53L0X_read_byte(deviceAddress, index, data);
+    status_int = VL53L0X_read_byte(deviceAddress, index, data, Dev->i2c);
 
     if (status_int != 0)
         Status = VL53L0X_ERROR_CONTROL_INTERFACE;
@@ -234,7 +234,7 @@ VL53L0X_Error VL53L0X_RdWord(VL53L0X_DEV Dev, uint8_t index, uint16_t *data){
 
     deviceAddress = Dev->I2cDevAddr;
 
-    status_int = VL53L0X_read_word(deviceAddress, index, data);
+    status_int = VL53L0X_read_word(deviceAddress, index, data, Dev->i2c);
 
     if (status_int != 0)
         Status = VL53L0X_ERROR_CONTROL_INTERFACE;
@@ -249,7 +249,7 @@ VL53L0X_Error  VL53L0X_RdDWord(VL53L0X_DEV Dev, uint8_t index, uint32_t *data){
 
     deviceAddress = Dev->I2cDevAddr;
 
-    status_int = VL53L0X_read_dword(deviceAddress, index, data);
+    status_int = VL53L0X_read_dword(deviceAddress, index, data, Dev->i2c);
 
     if (status_int != 0)
         Status = VL53L0X_ERROR_CONTROL_INTERFACE;

--- a/src/vl53l0x_i2c_platform.h
+++ b/src/vl53l0x_i2c_platform.h
@@ -2,12 +2,12 @@
 #include "Wire.h"
 
 // initialize I2C
-int VL53L0X_i2c_init(void);
-int VL53L0X_write_multi(uint8_t deviceAddress, uint8_t index, uint8_t *pdata, uint32_t count);
-int VL53L0X_read_multi(uint8_t deviceAddress, uint8_t index, uint8_t *pdata, uint32_t count);
-int VL53L0X_write_byte(uint8_t deviceAddress, uint8_t index, uint8_t data);
-int VL53L0X_write_word(uint8_t deviceAddress, uint8_t index, uint16_t data);
-int VL53L0X_write_dword(uint8_t deviceAddress, uint8_t index, uint32_t data);
-int VL53L0X_read_byte(uint8_t deviceAddress, uint8_t index, uint8_t *data);
-int VL53L0X_read_word(uint8_t deviceAddress, uint8_t index, uint16_t *data);
-int VL53L0X_read_dword(uint8_t deviceAddress, uint8_t index, uint32_t *data);
+int VL53L0X_i2c_init(TwoWire *i2c);
+int VL53L0X_write_multi(uint8_t deviceAddress, uint8_t index, uint8_t *pdata, uint32_t count, TwoWire *i2c);
+int VL53L0X_read_multi(uint8_t deviceAddress, uint8_t index, uint8_t *pdata, uint32_t count, TwoWire *i2c);
+int VL53L0X_write_byte(uint8_t deviceAddress, uint8_t index, uint8_t data, TwoWire *i2c);
+int VL53L0X_write_word(uint8_t deviceAddress, uint8_t index, uint16_t data, TwoWire *i2c);
+int VL53L0X_write_dword(uint8_t deviceAddress, uint8_t index, uint32_t data, TwoWire *i2c);
+int VL53L0X_read_byte(uint8_t deviceAddress, uint8_t index, uint8_t *data, TwoWire *i2c);
+int VL53L0X_read_word(uint8_t deviceAddress, uint8_t index, uint16_t *data, TwoWire *i2c);
+int VL53L0X_read_dword(uint8_t deviceAddress, uint8_t index, uint32_t *data, TwoWire *i2c);

--- a/src/vl53l0x_platform.h
+++ b/src/vl53l0x_platform.h
@@ -62,6 +62,8 @@ typedef struct {
     uint8_t   I2cDevAddr;                /*!< i2c device address user specific field */
     uint8_t   comms_type;                /*!< Type of comms : VL53L0X_COMMS_I2C or VL53L0X_COMMS_SPI */
     uint16_t  comms_speed_khz;           /*!< Comms speed [kHz] : typically 400kHz for I2C           */
+    
+    TwoWire   *i2c;
 
 } VL53L0X_Dev_t;
 


### PR DESCRIPTION
This should allow using the VL530L0X on the Arduino Due's alternate I2C Bus ("Wire1").
An extra parameter(with default value "Wire") has been added to the constructor to allow this.