### PR TITLE
fix product revision check

### DIFF
--- a/src/Adafruit_VL53L0X.cpp
+++ b/src/Adafruit_VL53L0X.cpp
@@ -97,7 +97,7 @@ boolean Adafruit_VL53L0X::begin(uint8_t i2c_addr, boolean debug, TwoWire *i2c) {
          Serial.print( F( ", Minor: " ) ); Serial.println( DeviceInfo.ProductRevisionMinor );
       }
 
-      if( ( DeviceInfo.ProductRevisionMinor != 1 ) && ( DeviceInfo.ProductRevisionMinor != 1 ) ) {
+      if( ( DeviceInfo.ProductRevisionMajor != 1 ) || ( DeviceInfo.ProductRevisionMinor != 1 ) ) {
           if( debug ) {
               Serial.print( F( "Error expected cut 1.1 but found " ) );
               Serial.print( DeviceInfo.ProductRevisionMajor );


### PR DESCRIPTION
With this Pull Request, the value of `DeviceInfo.ProductRevisionMajor` is checked.

NOTE:
Currently, `ProductRevisionMajor` is always set as 1, so this Pull Request does not affect the result of the check.
https://github.com/adafruit/Adafruit_VL53L0X/blob/master/src/core/src/vl53l0x_api_strings.cpp#L112