### PR TITLE
Remove unused variables

### DIFF
--- a/src/Adafruit_VL53L0X.cpp
+++ b/src/Adafruit_VL53L0X.cpp
@@ -50,9 +50,6 @@
 */
 /**************************************************************************/
 boolean Adafruit_VL53L0X::begin(uint8_t i2c_addr, boolean debug, TwoWire *i2c) {
-  int32_t status_int;
-  int32_t init_done = 0;
-
   uint32_t refSpadCount;
   uint8_t isApertureSpads;
   uint8_t VhvSettings;

--- a/src/Adafruit_VL53L0X.h
+++ b/src/Adafruit_VL53L0X.h
@@ -71,8 +71,6 @@ public:
 private:
   VL53L0X_Dev_t MyDevice;
   VL53L0X_Dev_t *pMyDevice = &MyDevice;
-  VL53L0X_Version_t Version;
-  VL53L0X_Version_t *pVersion = &Version;
   VL53L0X_DeviceInfo_t DeviceInfo;
 };
 


### PR DESCRIPTION
Changelog:
- In funcion `Adafruit_VL53L0X::begin` from VL53L0X.cpp archive I removed two unused variables (`status_int` and `init_done`).
- In VL53L0X.h I removed `Version` and `*Version`. I removed them because they are not used in any code snippets.