### PR TITLE
Fix overload xTalkCorrection

### DIFF
--- a/src/core/src/vl53l0x_api_core.cpp
+++ b/src/core/src/vl53l0x_api_core.cpp
@@ -1699,7 +1699,7 @@ VL53L0X_Error VL53L0X_calc_sigma_estimate(
     diff1_mcps <<= 8;
 
     /* FixPoint0824/FixPoint1616 = FixPoint2408 */
-    xTalkCorrection = (FixPoint1616_t)abs((long long)(diff1_mcps/diff2_mcps));
+    xTalkCorrection = (FixPoint1616_t)abs((long long)(diff1_mcps / diff2_mcps));
 
     /* FixPoint2408 << 8 = FixPoint1616 */
     xTalkCorrection <<= 8;

--- a/src/core/src/vl53l0x_api_core.cpp
+++ b/src/core/src/vl53l0x_api_core.cpp
@@ -1699,7 +1699,7 @@ VL53L0X_Error VL53L0X_calc_sigma_estimate(
     diff1_mcps <<= 8;
 
     /* FixPoint0824/FixPoint1616 = FixPoint2408 */
-    xTalkCorrection = abs(diff1_mcps / diff2_mcps);
+    xTalkCorrection = (FixPoint1616_t)abs((long long)(diff1_mcps/diff2_mcps));
 
     /* FixPoint2408 << 8 = FixPoint1616 */
     xTalkCorrection <<= 8;


### PR DESCRIPTION
AS explained in [this issue](https://github.com/stm32duino/Arduino_Core_STM32/issues/660), I have added the fix to prevent overload error:

```
vl53l0x_api_core.cpp:1702:50: error: call of overloaded 'abs(FixPoint1616_t)' is ambiguous

```

