### PR TITLE
Failed to boot error fix

### DIFF
--- a/examples/vl53l0x/vl53l0x.ino
+++ b/examples/vl53l0x/vl53l0x.ino
@@ -3,34 +3,46 @@
 Adafruit_VL53L0X lox = Adafruit_VL53L0X();
 
 void setup() {
-  Serial.begin(115200);
+  lox.begin(0x2B);// put any address between 0x29 to 0x7F
+  Serial.begin(9600);
 
   // wait until serial port opens for native USB devices
   while (! Serial) {
     delay(1);
   }
-  
+
   Serial.println("Adafruit VL53L0X test");
   if (!lox.begin()) {
     Serial.println(F("Failed to boot VL53L0X"));
-    while(1);
+    while (1);
   }
-  // power 
-  Serial.println(F("VL53L0X API Simple Ranging example\n\n")); 
+  // power
+  Serial.println(F("VL53L0X API Simple Ranging example\n\n"));
 }
 
 
 void loop() {
   VL53L0X_RangingMeasurementData_t measure;
-    
+
   Serial.print("Reading a measurement... ");
   lox.rangingTest(&measure, false); // pass in 'true' to get debug data printout!
 
   if (measure.RangeStatus != 4) {  // phase failures have incorrect data
-    Serial.print("Distance (mm): "); Serial.println(measure.RangeMilliMeter);
+    Serial.print("Distance (mm): ");
+    Serial.println(measure.RangeMilliMeter);
+
+    //  for centimeter remove comments
+
+    //    int centimeter;
+    //    centimeter = measure.RangeMilliMeter / 10; // convetrint mm into Cm
+    //    Serial.print("  , Distance (Cm): ");
+    //    Serial.print(centimeter);
+    //    Serial.println(" ");
+
+
   } else {
     Serial.println(" out of range ");
   }
-    
-  delay(100);
+
+  delay(200); //little delay to improve simulation performance
 }

--- a/examples/vl53l0x/vl53l0x.ino
+++ b/examples/vl53l0x/vl53l0x.ino
@@ -3,7 +3,7 @@
 Adafruit_VL53L0X lox = Adafruit_VL53L0X();
 
 void setup() {
-  lox.begin(0x2B);// put any address between 0x29 to 0x7F
+  lox.begin(0x29);// put any address between 0x29 to 0x7F
   Serial.begin(9600);
 
   // wait until serial port opens for native USB devices

--- a/examples/vl53l0x_oled/vl53l0x_oled.ino
+++ b/examples/vl53l0x_oled/vl53l0x_oled.ino
@@ -19,7 +19,7 @@ Adafruit_VL53L0X lox = Adafruit_VL53L0X();
 
 void setup()
 {
-  lox.begin(0x2B);// put any address between 0x29 to 0x7F
+  lox.begin(0x29);// put any address between 0x29 to 0x7F
   Serial.begin(9600);
 
   display.begin(SSD1306_SWITCHCAPVCC, 0x3C);  // initialize with the I2C addr 0x3C (for the 128x32)

--- a/examples/vl53l0x_oled/vl53l0x_oled.ino
+++ b/examples/vl53l0x_oled/vl53l0x_oled.ino
@@ -1,7 +1,7 @@
 /* This example shows how to take
-range measurements with the VL53L0X and display on a SSD1306 OLED.
+  range measurements with the VL53L0X and display on a SSD1306 OLED.
 
-The range readings are in units of mm. */
+  The range readings are in units of mm. */
 
 #include <Wire.h>
 #include "Adafruit_VL53L0X.h"
@@ -14,24 +14,25 @@ Adafruit_SSD1306 display = Adafruit_SSD1306();
 Adafruit_VL53L0X lox = Adafruit_VL53L0X();
 
 #if (SSD1306_LCDHEIGHT != 32)
- #error("Height incorrect, please fix Adafruit_SSD1306.h!");
+#error("Height incorrect, please fix Adafruit_SSD1306.h!");
 #endif
 
 void setup()
 {
+  lox.begin(0x2B);// put any address between 0x29 to 0x7F
   Serial.begin(9600);
-    
+
   display.begin(SSD1306_SWITCHCAPVCC, 0x3C);  // initialize with the I2C addr 0x3C (for the 128x32)
   // init done
   display.display();
   delay(1000);
-    
-  
+
+
   Wire.begin();
 
   if (!lox.begin()) {
     Serial.println(F("Failed to boot VL53L0X"));
-    while(1);
+    while (1);
   }
 
   // text display big!
@@ -46,13 +47,13 @@ void loop()
   lox.rangingTest(&measure, false); // pass in 'true' to get debug data printout!
 
   if (measure.RangeStatus != 4) {  // phase failures have incorrect data
-      display.clearDisplay();
-      display.setCursor(0,0);
-      display.print(measure.RangeMilliMeter);
-      display.print("mm");
-      display.display();
-      Serial.println();
-      delay(50);
+    display.clearDisplay();
+    display.setCursor(0, 0);
+    display.print(measure.RangeMilliMeter);
+    display.print("mm");
+    display.display();
+    Serial.println();
+    delay(50);
   } else {
     display.display();
     display.clearDisplay();


### PR DESCRIPTION
The update example programs  (1) vl53l0x (2) vl53l0x_oled  were modified 
because the previous program does not contain the I2C address of the vl53lox sensor as the resulted sensor failed to begin!

I2C only allows one address-per-device, so it is necessary to sure each I2C device has a unique address during initialization; instead of calling lox.begin(), call lox.begin(0x2B).

In (1) example program of vl53l0x sensor, a millimeter to Centimeter function added too, since it's pretty useful some time to deal with bigger units also describe to the user so, they can add their units too.
 
There are no limitations with changes. The only modification was added to eliminate the failure to boot error (vl53l0x).

Thanks & Regards 

Abhijeet Kumar 

