### PR TITLE
Add continuous example

### DIFF
--- a/examples/vl53l0x_continuous/vl53l0x_continuous.ino
+++ b/examples/vl53l0x_continuous/vl53l0x_continuous.ino
@@ -1,0 +1,30 @@
+#include "Adafruit_VL53L0X.h"
+
+Adafruit_VL53L0X lox = Adafruit_VL53L0X();
+
+void setup() {
+  Serial.begin(115200);
+
+  // wait until serial port opens for native USB devices
+  while (! Serial) {
+    delay(1);
+  }
+
+  Serial.println("Adafruit VL53L0X test.");
+  if (!lox.begin()) {
+    Serial.println(F("Failed to boot VL53L0X"));
+    while(1);
+  }
+  // power
+  Serial.println(F("VL53L0X API Continuous Ranging example\n\n"));
+
+  // start continuous ranging
+  lox.startRangeContinuous();
+}
+
+void loop() {
+  if (lox.isRangeComplete()) {
+    Serial.print("Distance in mm: ");
+    Serial.println(lox.readRange());
+  }
+}


### PR DESCRIPTION
As requested in #13. Not sure if "continuous" just means printing values in a loop, which current example already does, or actually using the continuous mode of the VL53L0X.

This PR adds a basic example of using continuous **mode**. Looks like there might be various ways it could be done, based on API layout. But this is a simple looping example.

![Screenshot from 2022-03-15 11-41-05](https://user-images.githubusercontent.com/8755041/158449778-780b22bc-0a52-4025-9bc9-10f00ad9ef78.png)

