### PR TITLE
Fix ESP32 v2.0.5 BSP Compilation

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit_VL53L0X
-version=1.2.0
+version=1.2.1
 author=Adafruit
 maintainer=adafruit <support@adafruit.com>
 sentence=Sensor driver for VL53L0X Time of Flight sensor

--- a/src/core/src/vl53l0x_api.cpp
+++ b/src/core/src/vl53l0x_api.cpp
@@ -528,7 +528,8 @@ VL53L0X_GetTuningSettingBuffer(VL53L0X_DEV Dev, uint8_t **ppTuningSettingBuffer,
 
 VL53L0X_Error VL53L0X_StaticInit(VL53L0X_DEV Dev) {
   VL53L0X_Error Status = VL53L0X_ERROR_NONE;
-  VL53L0X_DeviceParameters_t CurrentParameters = {0};
+  VL53L0X_DeviceParameters_t CurrentParameters = {0, 0, 0, 0, 0, 0,
+                                                  0, 0, 0, 0, 0, 0};
   uint8_t *pTuningSettingBuffer;
   uint16_t tempword = 0;
   uint8_t tempbyte = 0;

--- a/src/core/src/vl53l0x_api.cpp
+++ b/src/core/src/vl53l0x_api.cpp
@@ -528,8 +528,7 @@ VL53L0X_GetTuningSettingBuffer(VL53L0X_DEV Dev, uint8_t **ppTuningSettingBuffer,
 
 VL53L0X_Error VL53L0X_StaticInit(VL53L0X_DEV Dev) {
   VL53L0X_Error Status = VL53L0X_ERROR_NONE;
-  VL53L0X_DeviceParameters_t CurrentParameters = {0, 0, 0, 0, 0, 0,
-                                                  0, 0, 0, 0, 0, 0};
+  VL53L0X_DeviceParameters_t CurrentParameters;
   uint8_t *pTuningSettingBuffer;
   uint16_t tempword = 0;
   uint8_t tempbyte = 0;


### PR DESCRIPTION
Fixes https://github.com/adafruit/Adafruit_VL53L0X/issues/58 caused by ESP32 v2.0.5 GCC not liking aggregate list initialization of a struct by initializing the struct with default values (identical to init within: https://github.com/adafruit/Adafruit_VL53L0X/blob/master/src/core/src/vl53l0x_api.cpp#L349)

@hathach  This warning was thrown within adabot's bsp v2.0.5 run, but uncaught (see: https://github.com/adafruit/Adafruit_VL53L0X/actions/runs/3290641110/jobs/5423754538#step:6:5974). Was it supposed to be?