### PR TITLE
Fix reset (shutdown pin) - configuring as output pin mode

### DIFF
--- a/examples/vl53l0x_Interrupt/vl53l0x_Interrupt.ino
+++ b/examples/vl53l0x_Interrupt/vl53l0x_Interrupt.ino
@@ -13,6 +13,7 @@ void setup() {
   }
   Serial.println(F("VL53L0X API Interrupt Ranging example\n\n"));
 
+  pinMode(VL53LOX_ShutdownPin, OUTPUT);
   pinMode(VL53LOX_ShutdownPin, INPUT_PULLUP);
   pinMode(VL53LOX_InterruptPin, INPUT_PULLUP);
   attachInterrupt(digitalPinToInterrupt(VL53LOX_InterruptPin), VL53LOXISR,

--- a/examples/vl53l0x_Interrupt/vl53l0x_Interrupt.ino
+++ b/examples/vl53l0x_Interrupt/vl53l0x_Interrupt.ino
@@ -1,8 +1,16 @@
 #include "Adafruit_VL53L0X.h"
 const byte VL53L0X_InterruptPin = 6;
 const byte VL53L0X_ShutdownPin = 9;
-volatile byte VL53L0X_State = LOW;
+volatile VL53L0X_State VL53L0X_State_ = LOW;
 Adafruit_VL53L0X lox = Adafruit_VL53L0X();
+
+void VL53L0XISR() {
+  // Read if we are high or low
+  VL53L0X_State_ = digitalRead(VL53L0X_InterruptPin);
+  // set the built in LED to reflect in range on for Out of range off for in
+  // range
+  digitalWrite(LED_BUILTIN, VL53L0X_State_);
+}
 
 void setup() {
   Serial.begin(115200);
@@ -62,16 +70,8 @@ void setup() {
   lox.startMeasurement();
 }
 
-void VL53L0XISR() {
-  // Read if we are high or low
-  VL53L0X_State = digitalRead(VL53L0X_InterruptPin);
-  // set the built in LED to reflect in range on for Out of range off for in
-  // range
-  digitalWrite(LED_BUILTIN, VL53L0X_State);
-}
-
 void loop() {
-  if (VL53L0X_State == LOW) {
+  if (VL53L0X_State_ == LOW) {
     VL53L0X_RangingMeasurementData_t measure;
     Serial.print("Reading a measurement... ");
     lox.getRangingMeasurement(

--- a/examples/vl53l0x_Interrupt/vl53l0x_Interrupt.ino
+++ b/examples/vl53l0x_Interrupt/vl53l0x_Interrupt.ino
@@ -1,7 +1,7 @@
 #include "Adafruit_VL53L0X.h"
-const byte VL53LOX_InterruptPin = 6;
-const byte VL53LOX_ShutdownPin = 9;
-volatile byte VL53LOX_State = LOW;
+const byte VL53L0X_InterruptPin = 6;
+const byte VL53L0X_ShutdownPin = 9;
+volatile byte VL53L0X_State = LOW;
 Adafruit_VL53L0X lox = Adafruit_VL53L0X();
 
 void setup() {
@@ -13,23 +13,24 @@ void setup() {
   }
   Serial.println(F("VL53L0X API Interrupt Ranging example\n\n"));
 
-  pinMode(VL53LOX_ShutdownPin, OUTPUT);
-  pinMode(VL53LOX_ShutdownPin, INPUT_PULLUP);
-  pinMode(VL53LOX_InterruptPin, INPUT_PULLUP);
-  attachInterrupt(digitalPinToInterrupt(VL53LOX_InterruptPin), VL53LOXISR,
+  pinMode(VL53L0X_ShutdownPin, OUTPUT);
+  
+  pinMode(VL53L0X_ShutdownPin, INPUT_PULLUP);
+  pinMode(VL53L0X_InterruptPin, INPUT_PULLUP);
+  attachInterrupt(digitalPinToInterrupt(VL53L0X_InterruptPin), VL53L0XISR,
                   CHANGE);
   pinMode(LED_BUILTIN, OUTPUT);
   digitalWrite(LED_BUILTIN, LOW);
 
-  // if lox.begin failes its becasue it was a warm boot and the VL53LOX is in
-  // continues mesurement mode we can use an IO pin to reset the device in case
+  // if lox.begin fails its because it was a warm boot and the VL53L0X is in
+  // continues measurement mode we can use an IO pin to reset the device in case
   // we get stuck in this mode
   while (!lox.begin()) {
     Serial.println(F("Failed to boot VL53L0X"));
     Serial.println("Adafruit VL53L0X XShut set Low to Force HW Reset");
-    digitalWrite(VL53LOX_ShutdownPin, LOW);
+    digitalWrite(VL53L0X_ShutdownPin, LOW);
     delay(100);
-    digitalWrite(VL53LOX_ShutdownPin, HIGH);
+    digitalWrite(VL53L0X_ShutdownPin, HIGH);
     Serial.println("Adafruit VL53L0X XShut set high to Allow Boot");
     delay(100);
   }
@@ -46,14 +47,14 @@ void setup() {
                     VL53L0X_GPIOFUNCTIONALITY_THRESHOLD_CROSSED_LOW,
                     VL53L0X_INTERRUPTPOLARITY_LOW);
 
-  // Set Interrupt Treashholds
+  // Set Interrupt Thresholds
   // Low reading set to 50mm  High Set to 100mm
-  FixPoint1616_t LowThreashHold = (50 * 65536.0);
-  FixPoint1616_t HighThreashHold = (100 * 65536.0);
-  Serial.println("Set Interrupt Threasholds... ");
-  lox.setInterruptThresholds(LowThreashHold, HighThreashHold, true);
+  FixPoint1616_t LowThreshold = (50 * 65536.0);
+  FixPoint1616_t HighThreshold = (100 * 65536.0);
+  Serial.println("Set Interrupt Thresholds... ");
+  lox.setInterruptThresholds(LowThreshold, HighThreshold, true);
 
-  // Enable Continous Measurement Mode
+  // Enable Continuous Measurement Mode
   Serial.println("Set Mode VL53L0X_DEVICEMODE_CONTINUOUS_RANGING... ");
   lox.setDeviceMode(VL53L0X_DEVICEMODE_CONTINUOUS_RANGING, false);
 
@@ -61,16 +62,16 @@ void setup() {
   lox.startMeasurement();
 }
 
-void VL53LOXISR() {
+void VL53L0XISR() {
   // Read if we are high or low
-  VL53LOX_State = digitalRead(VL53LOX_InterruptPin);
+  VL53L0X_State = digitalRead(VL53L0X_InterruptPin);
   // set the built in LED to reflect in range on for Out of range off for in
   // range
-  digitalWrite(LED_BUILTIN, VL53LOX_State);
+  digitalWrite(LED_BUILTIN, VL53L0X_State);
 }
 
 void loop() {
-  if (VL53LOX_State == LOW) {
+  if (VL53L0X_State == LOW) {
     VL53L0X_RangingMeasurementData_t measure;
     Serial.print("Reading a measurement... ");
     lox.getRangingMeasurement(

--- a/src/platform/src/vl53l0x_i2c_comms.cpp
+++ b/src/platform/src/vl53l0x_i2c_comms.cpp
@@ -1,15 +1,16 @@
 #include "../../vl53l0x_def.h"
 #include "../../vl53l0x_i2c_platform.h"
 
-//#define I2C_DEBUG
+// #define I2C_DEBUG
 
 VL53L0X_Error VL53L0X_i2c_init(TwoWire *i2c) {
   i2c->begin();
   return VL53L0X_ERROR_NONE;
 }
 
-VL53L0X_Error VL53L0X_write_multi(uint8_t deviceAddress, uint8_t index, uint8_t *pdata,
-                        uint32_t count, TwoWire *i2c) {
+VL53L0X_Error VL53L0X_write_multi(uint8_t deviceAddress, uint8_t index,
+                                  uint8_t *pdata, uint32_t count,
+                                  TwoWire *i2c) {
   i2c->beginTransmission(deviceAddress);
   i2c->write(index);
 #ifdef I2C_DEBUG
@@ -35,8 +36,8 @@ VL53L0X_Error VL53L0X_write_multi(uint8_t deviceAddress, uint8_t index, uint8_t 
   return VL53L0X_ERROR_NONE;
 }
 
-VL53L0X_Error VL53L0X_read_multi(uint8_t deviceAddress, uint8_t index, uint8_t *pdata,
-                       uint32_t count, TwoWire *i2c) {
+VL53L0X_Error VL53L0X_read_multi(uint8_t deviceAddress, uint8_t index,
+                                 uint8_t *pdata, uint32_t count, TwoWire *i2c) {
   i2c->beginTransmission(deviceAddress);
   i2c->write(index);
   i2c->endTransmission();
@@ -64,21 +65,21 @@ VL53L0X_Error VL53L0X_read_multi(uint8_t deviceAddress, uint8_t index, uint8_t *
   return VL53L0X_ERROR_NONE;
 }
 
-VL53L0X_Error VL53L0X_write_byte(uint8_t deviceAddress, uint8_t index, uint8_t data,
-                       TwoWire *i2c) {
+VL53L0X_Error VL53L0X_write_byte(uint8_t deviceAddress, uint8_t index,
+                                 uint8_t data, TwoWire *i2c) {
   return VL53L0X_write_multi(deviceAddress, index, &data, 1, i2c);
 }
 
-VL53L0X_Error VL53L0X_write_word(uint8_t deviceAddress, uint8_t index, uint16_t data,
-                       TwoWire *i2c) {
+VL53L0X_Error VL53L0X_write_word(uint8_t deviceAddress, uint8_t index,
+                                 uint16_t data, TwoWire *i2c) {
   uint8_t buff[2];
   buff[1] = data & 0xFF;
   buff[0] = data >> 8;
   return VL53L0X_write_multi(deviceAddress, index, buff, 2, i2c);
 }
 
-VL53L0X_Error VL53L0X_write_dword(uint8_t deviceAddress, uint8_t index, uint32_t data,
-                        TwoWire *i2c) {
+VL53L0X_Error VL53L0X_write_dword(uint8_t deviceAddress, uint8_t index,
+                                  uint32_t data, TwoWire *i2c) {
   uint8_t buff[4];
 
   buff[3] = data & 0xFF;
@@ -89,13 +90,13 @@ VL53L0X_Error VL53L0X_write_dword(uint8_t deviceAddress, uint8_t index, uint32_t
   return VL53L0X_write_multi(deviceAddress, index, buff, 4, i2c);
 }
 
-VL53L0X_Error VL53L0X_read_byte(uint8_t deviceAddress, uint8_t index, uint8_t *data,
-                      TwoWire *i2c) {
+VL53L0X_Error VL53L0X_read_byte(uint8_t deviceAddress, uint8_t index,
+                                uint8_t *data, TwoWire *i2c) {
   return VL53L0X_read_multi(deviceAddress, index, data, 1, i2c);
 }
 
-VL53L0X_Error VL53L0X_read_word(uint8_t deviceAddress, uint8_t index, uint16_t *data,
-                      TwoWire *i2c) {
+VL53L0X_Error VL53L0X_read_word(uint8_t deviceAddress, uint8_t index,
+                                uint16_t *data, TwoWire *i2c) {
   uint8_t buff[2];
   VL53L0X_Error r = VL53L0X_read_multi(deviceAddress, index, buff, 2, i2c);
 
@@ -108,8 +109,8 @@ VL53L0X_Error VL53L0X_read_word(uint8_t deviceAddress, uint8_t index, uint16_t *
   return r;
 }
 
-VL53L0X_Error VL53L0X_read_dword(uint8_t deviceAddress, uint8_t index, uint32_t *data,
-                       TwoWire *i2c) {
+VL53L0X_Error VL53L0X_read_dword(uint8_t deviceAddress, uint8_t index,
+                                 uint32_t *data, TwoWire *i2c) {
   uint8_t buff[4];
   VL53L0X_Error r = VL53L0X_read_multi(deviceAddress, index, buff, 4, i2c);
 

--- a/src/platform/src/vl53l0x_i2c_comms.cpp
+++ b/src/platform/src/vl53l0x_i2c_comms.cpp
@@ -3,12 +3,12 @@
 
 //#define I2C_DEBUG
 
-int VL53L0X_i2c_init(TwoWire *i2c) {
+VL53L0X_Error VL53L0X_i2c_init(TwoWire *i2c) {
   i2c->begin();
   return VL53L0X_ERROR_NONE;
 }
 
-int VL53L0X_write_multi(uint8_t deviceAddress, uint8_t index, uint8_t *pdata,
+VL53L0X_Error VL53L0X_write_multi(uint8_t deviceAddress, uint8_t index, uint8_t *pdata,
                         uint32_t count, TwoWire *i2c) {
   i2c->beginTransmission(deviceAddress);
   i2c->write(index);
@@ -35,7 +35,7 @@ int VL53L0X_write_multi(uint8_t deviceAddress, uint8_t index, uint8_t *pdata,
   return VL53L0X_ERROR_NONE;
 }
 
-int VL53L0X_read_multi(uint8_t deviceAddress, uint8_t index, uint8_t *pdata,
+VL53L0X_Error VL53L0X_read_multi(uint8_t deviceAddress, uint8_t index, uint8_t *pdata,
                        uint32_t count, TwoWire *i2c) {
   i2c->beginTransmission(deviceAddress);
   i2c->write(index);
@@ -64,12 +64,12 @@ int VL53L0X_read_multi(uint8_t deviceAddress, uint8_t index, uint8_t *pdata,
   return VL53L0X_ERROR_NONE;
 }
 
-int VL53L0X_write_byte(uint8_t deviceAddress, uint8_t index, uint8_t data,
+VL53L0X_Error VL53L0X_write_byte(uint8_t deviceAddress, uint8_t index, uint8_t data,
                        TwoWire *i2c) {
   return VL53L0X_write_multi(deviceAddress, index, &data, 1, i2c);
 }
 
-int VL53L0X_write_word(uint8_t deviceAddress, uint8_t index, uint16_t data,
+VL53L0X_Error VL53L0X_write_word(uint8_t deviceAddress, uint8_t index, uint16_t data,
                        TwoWire *i2c) {
   uint8_t buff[2];
   buff[1] = data & 0xFF;
@@ -77,7 +77,7 @@ int VL53L0X_write_word(uint8_t deviceAddress, uint8_t index, uint16_t data,
   return VL53L0X_write_multi(deviceAddress, index, buff, 2, i2c);
 }
 
-int VL53L0X_write_dword(uint8_t deviceAddress, uint8_t index, uint32_t data,
+VL53L0X_Error VL53L0X_write_dword(uint8_t deviceAddress, uint8_t index, uint32_t data,
                         TwoWire *i2c) {
   uint8_t buff[4];
 
@@ -89,12 +89,12 @@ int VL53L0X_write_dword(uint8_t deviceAddress, uint8_t index, uint32_t data,
   return VL53L0X_write_multi(deviceAddress, index, buff, 4, i2c);
 }
 
-int VL53L0X_read_byte(uint8_t deviceAddress, uint8_t index, uint8_t *data,
+VL53L0X_Error VL53L0X_read_byte(uint8_t deviceAddress, uint8_t index, uint8_t *data,
                       TwoWire *i2c) {
   return VL53L0X_read_multi(deviceAddress, index, data, 1, i2c);
 }
 
-int VL53L0X_read_word(uint8_t deviceAddress, uint8_t index, uint16_t *data,
+VL53L0X_Error VL53L0X_read_word(uint8_t deviceAddress, uint8_t index, uint16_t *data,
                       TwoWire *i2c) {
   uint8_t buff[2];
   int r = VL53L0X_read_multi(deviceAddress, index, buff, 2, i2c);
@@ -108,7 +108,7 @@ int VL53L0X_read_word(uint8_t deviceAddress, uint8_t index, uint16_t *data,
   return r;
 }
 
-int VL53L0X_read_dword(uint8_t deviceAddress, uint8_t index, uint32_t *data,
+VL53L0X_Error VL53L0X_read_dword(uint8_t deviceAddress, uint8_t index, uint32_t *data,
                        TwoWire *i2c) {
   uint8_t buff[4];
   int r = VL53L0X_read_multi(deviceAddress, index, buff, 4, i2c);

--- a/src/platform/src/vl53l0x_i2c_comms.cpp
+++ b/src/platform/src/vl53l0x_i2c_comms.cpp
@@ -97,7 +97,7 @@ VL53L0X_Error VL53L0X_read_byte(uint8_t deviceAddress, uint8_t index, uint8_t *d
 VL53L0X_Error VL53L0X_read_word(uint8_t deviceAddress, uint8_t index, uint16_t *data,
                       TwoWire *i2c) {
   uint8_t buff[2];
-  int r = VL53L0X_read_multi(deviceAddress, index, buff, 2, i2c);
+  VL53L0X_Error r = VL53L0X_read_multi(deviceAddress, index, buff, 2, i2c);
 
   uint16_t tmp;
   tmp = buff[0];
@@ -111,7 +111,7 @@ VL53L0X_Error VL53L0X_read_word(uint8_t deviceAddress, uint8_t index, uint16_t *
 VL53L0X_Error VL53L0X_read_dword(uint8_t deviceAddress, uint8_t index, uint32_t *data,
                        TwoWire *i2c) {
   uint8_t buff[4];
-  int r = VL53L0X_read_multi(deviceAddress, index, buff, 4, i2c);
+  VL53L0X_Error r = VL53L0X_read_multi(deviceAddress, index, buff, 4, i2c);
 
   uint32_t tmp;
   tmp = buff[0];

--- a/src/platform/src/vl53l0x_platform.cpp
+++ b/src/platform/src/vl53l0x_platform.cpp
@@ -135,6 +135,7 @@ VL53L0X_Error VL53L0X_WriteMulti(VL53L0X_DEV Dev, uint8_t index, uint8_t *pdata,
 // the ranging_sensor_comms.dll will take care of the page selection
 VL53L0X_Error VL53L0X_ReadMulti(VL53L0X_DEV Dev, uint8_t index, uint8_t *pdata,
                                 uint32_t count) {
+  VL53L0X_I2C_USER_VAR
   VL53L0X_Error Status = VL53L0X_ERROR_NONE;
   VL53L0X_Error command_status;
   uint8_t deviceAddress;
@@ -145,7 +146,8 @@ VL53L0X_Error VL53L0X_ReadMulti(VL53L0X_DEV Dev, uint8_t index, uint8_t *pdata,
 
   deviceAddress = Dev->I2cDevAddr;
 
-  command_status = VL53L0X_read_multi(deviceAddress, index, pdata, count, Dev->i2c);
+  command_status =
+      VL53L0X_read_multi(deviceAddress, index, pdata, count, Dev->i2c);
 
   if (command_status != VL53L0X_ERROR_NONE)
     Status = VL53L0X_ERROR_CONTROL_INTERFACE;

--- a/src/platform/src/vl53l0x_platform.cpp
+++ b/src/platform/src/vl53l0x_platform.cpp
@@ -135,7 +135,6 @@ VL53L0X_Error VL53L0X_WriteMulti(VL53L0X_DEV Dev, uint8_t index, uint8_t *pdata,
 // the ranging_sensor_comms.dll will take care of the page selection
 VL53L0X_Error VL53L0X_ReadMulti(VL53L0X_DEV Dev, uint8_t index, uint8_t *pdata,
                                 uint32_t count) {
-  VL53L0X_I2C_USER_VAR
   VL53L0X_Error Status = VL53L0X_ERROR_NONE;
   VL53L0X_Error command_status;
   uint8_t deviceAddress;

--- a/src/platform/src/vl53l0x_platform.cpp
+++ b/src/platform/src/vl53l0x_platform.cpp
@@ -114,7 +114,7 @@ VL53L0X_Error VL53L0X_WriteMulti(VL53L0X_DEV Dev, uint8_t index, uint8_t *pdata,
                                  uint32_t count) {
 
   VL53L0X_Error Status = VL53L0X_ERROR_NONE;
-  int32_t status_int = 0;
+  VL53L0X_Error command_status = 0;
   uint8_t deviceAddress;
 
   if (count >= VL53L0X_MAX_I2C_XFER_SIZE) {
@@ -123,10 +123,10 @@ VL53L0X_Error VL53L0X_WriteMulti(VL53L0X_DEV Dev, uint8_t index, uint8_t *pdata,
 
   deviceAddress = Dev->I2cDevAddr;
 
-  status_int =
+  command_status =
       VL53L0X_write_multi(deviceAddress, index, pdata, count, Dev->i2c);
 
-  if (status_int != 0)
+  if (command_status != VL53L0X_ERROR_NONE)
     Status = VL53L0X_ERROR_CONTROL_INTERFACE;
 
   return Status;
@@ -137,7 +137,7 @@ VL53L0X_Error VL53L0X_ReadMulti(VL53L0X_DEV Dev, uint8_t index, uint8_t *pdata,
                                 uint32_t count) {
   VL53L0X_I2C_USER_VAR
   VL53L0X_Error Status = VL53L0X_ERROR_NONE;
-  int32_t status_int;
+  VL53L0X_Error command_status;
   uint8_t deviceAddress;
 
   if (count >= VL53L0X_MAX_I2C_XFER_SIZE) {
@@ -146,9 +146,9 @@ VL53L0X_Error VL53L0X_ReadMulti(VL53L0X_DEV Dev, uint8_t index, uint8_t *pdata,
 
   deviceAddress = Dev->I2cDevAddr;
 
-  status_int = VL53L0X_read_multi(deviceAddress, index, pdata, count, Dev->i2c);
+  command_status = VL53L0X_read_multi(deviceAddress, index, pdata, count, Dev->i2c);
 
-  if (status_int != 0)
+  if (command_status != VL53L0X_ERROR_NONE)
     Status = VL53L0X_ERROR_CONTROL_INTERFACE;
 
   return Status;
@@ -156,14 +156,14 @@ VL53L0X_Error VL53L0X_ReadMulti(VL53L0X_DEV Dev, uint8_t index, uint8_t *pdata,
 
 VL53L0X_Error VL53L0X_WrByte(VL53L0X_DEV Dev, uint8_t index, uint8_t data) {
   VL53L0X_Error Status = VL53L0X_ERROR_NONE;
-  int32_t status_int;
+  VL53L0X_Error command_status;
   uint8_t deviceAddress;
 
   deviceAddress = Dev->I2cDevAddr;
 
-  status_int = VL53L0X_write_byte(deviceAddress, index, data, Dev->i2c);
+  command_status = VL53L0X_write_byte(deviceAddress, index, data, Dev->i2c);
 
-  if (status_int != 0)
+  if (command_status != VL53L0X_ERROR_NONE)
     Status = VL53L0X_ERROR_CONTROL_INTERFACE;
 
   return Status;
@@ -171,14 +171,14 @@ VL53L0X_Error VL53L0X_WrByte(VL53L0X_DEV Dev, uint8_t index, uint8_t data) {
 
 VL53L0X_Error VL53L0X_WrWord(VL53L0X_DEV Dev, uint8_t index, uint16_t data) {
   VL53L0X_Error Status = VL53L0X_ERROR_NONE;
-  int32_t status_int;
+  VL53L0X_Error command_status;
   uint8_t deviceAddress;
 
   deviceAddress = Dev->I2cDevAddr;
 
-  status_int = VL53L0X_write_word(deviceAddress, index, data, Dev->i2c);
+  command_status = VL53L0X_write_word(deviceAddress, index, data, Dev->i2c);
 
-  if (status_int != 0)
+  if (command_status != VL53L0X_ERROR_NONE)
     Status = VL53L0X_ERROR_CONTROL_INTERFACE;
 
   return Status;
@@ -186,14 +186,14 @@ VL53L0X_Error VL53L0X_WrWord(VL53L0X_DEV Dev, uint8_t index, uint16_t data) {
 
 VL53L0X_Error VL53L0X_WrDWord(VL53L0X_DEV Dev, uint8_t index, uint32_t data) {
   VL53L0X_Error Status = VL53L0X_ERROR_NONE;
-  int32_t status_int;
+  VL53L0X_Error command_status;
   uint8_t deviceAddress;
 
   deviceAddress = Dev->I2cDevAddr;
 
-  status_int = VL53L0X_write_dword(deviceAddress, index, data, Dev->i2c);
+  command_status = VL53L0X_write_dword(deviceAddress, index, data, Dev->i2c);
 
-  if (status_int != 0)
+  if (command_status != VL53L0X_ERROR_NONE)
     Status = VL53L0X_ERROR_CONTROL_INTERFACE;
 
   return Status;
@@ -202,22 +202,22 @@ VL53L0X_Error VL53L0X_WrDWord(VL53L0X_DEV Dev, uint8_t index, uint32_t data) {
 VL53L0X_Error VL53L0X_UpdateByte(VL53L0X_DEV Dev, uint8_t index,
                                  uint8_t AndData, uint8_t OrData) {
   VL53L0X_Error Status = VL53L0X_ERROR_NONE;
-  int32_t status_int;
+  VL53L0X_Error command_status;
   uint8_t deviceAddress;
   uint8_t data;
 
   deviceAddress = Dev->I2cDevAddr;
 
-  status_int = VL53L0X_read_byte(deviceAddress, index, &data, Dev->i2c);
+  command_status = VL53L0X_read_byte(deviceAddress, index, &data, Dev->i2c);
 
-  if (status_int != 0)
+  if (command_status != VL53L0X_ERROR_NONE)
     Status = VL53L0X_ERROR_CONTROL_INTERFACE;
 
   if (Status == VL53L0X_ERROR_NONE) {
     data = (data & AndData) | OrData;
-    status_int = VL53L0X_write_byte(deviceAddress, index, data, Dev->i2c);
+    command_status = VL53L0X_write_byte(deviceAddress, index, data, Dev->i2c);
 
-    if (status_int != 0)
+    if (command_status != VL53L0X_ERROR_NONE)
       Status = VL53L0X_ERROR_CONTROL_INTERFACE;
   }
 
@@ -226,14 +226,14 @@ VL53L0X_Error VL53L0X_UpdateByte(VL53L0X_DEV Dev, uint8_t index,
 
 VL53L0X_Error VL53L0X_RdByte(VL53L0X_DEV Dev, uint8_t index, uint8_t *data) {
   VL53L0X_Error Status = VL53L0X_ERROR_NONE;
-  int32_t status_int;
+  VL53L0X_Error command_status;
   uint8_t deviceAddress;
 
   deviceAddress = Dev->I2cDevAddr;
 
-  status_int = VL53L0X_read_byte(deviceAddress, index, data, Dev->i2c);
+  command_status = VL53L0X_read_byte(deviceAddress, index, data, Dev->i2c);
 
-  if (status_int != 0)
+  if (command_status != VL53L0X_ERROR_NONE)
     Status = VL53L0X_ERROR_CONTROL_INTERFACE;
 
   return Status;
@@ -241,14 +241,14 @@ VL53L0X_Error VL53L0X_RdByte(VL53L0X_DEV Dev, uint8_t index, uint8_t *data) {
 
 VL53L0X_Error VL53L0X_RdWord(VL53L0X_DEV Dev, uint8_t index, uint16_t *data) {
   VL53L0X_Error Status = VL53L0X_ERROR_NONE;
-  int32_t status_int;
+  VL53L0X_Error command_status;
   uint8_t deviceAddress;
 
   deviceAddress = Dev->I2cDevAddr;
 
-  status_int = VL53L0X_read_word(deviceAddress, index, data, Dev->i2c);
+  command_status = VL53L0X_read_word(deviceAddress, index, data, Dev->i2c);
 
-  if (status_int != 0)
+  if (command_status != VL53L0X_ERROR_NONE)
     Status = VL53L0X_ERROR_CONTROL_INTERFACE;
 
   return Status;
@@ -256,14 +256,14 @@ VL53L0X_Error VL53L0X_RdWord(VL53L0X_DEV Dev, uint8_t index, uint16_t *data) {
 
 VL53L0X_Error VL53L0X_RdDWord(VL53L0X_DEV Dev, uint8_t index, uint32_t *data) {
   VL53L0X_Error Status = VL53L0X_ERROR_NONE;
-  int32_t status_int;
+  VL53L0X_Error command_status;
   uint8_t deviceAddress;
 
   deviceAddress = Dev->I2cDevAddr;
 
-  status_int = VL53L0X_read_dword(deviceAddress, index, data, Dev->i2c);
+  command_status = VL53L0X_read_dword(deviceAddress, index, data, Dev->i2c);
 
-  if (status_int != 0)
+  if (command_status != VL53L0X_ERROR_NONE)
     Status = VL53L0X_ERROR_CONTROL_INTERFACE;
 
   return Status;

--- a/src/vl53l0x_def.h
+++ b/src/vl53l0x_def.h
@@ -124,44 +124,44 @@ typedef struct {
 typedef int8_t VL53L0X_Error;
 
 #define VL53L0X_ERROR_NONE ((VL53L0X_Error)0)
-#define VL53L0X_ERROR_CALIBRATION_WARNING ((VL53L0X_Error)-1)
+#define VL53L0X_ERROR_CALIBRATION_WARNING ((VL53L0X_Error) - 1)
 /*!< Warning invalid calibration data may be in used
         \a	VL53L0X_InitData()
         \a VL53L0X_GetOffsetCalibrationData
         \a VL53L0X_SetOffsetCalibrationData */
-#define VL53L0X_ERROR_MIN_CLIPPED ((VL53L0X_Error)-2)
+#define VL53L0X_ERROR_MIN_CLIPPED ((VL53L0X_Error) - 2)
 /*!< Warning parameter passed was clipped to min before to be applied */
 
-#define VL53L0X_ERROR_UNDEFINED ((VL53L0X_Error)-3)
+#define VL53L0X_ERROR_UNDEFINED ((VL53L0X_Error) - 3)
 /*!< Unqualified error */
-#define VL53L0X_ERROR_INVALID_PARAMS ((VL53L0X_Error)-4)
+#define VL53L0X_ERROR_INVALID_PARAMS ((VL53L0X_Error) - 4)
 /*!< Parameter passed is invalid or out of range */
-#define VL53L0X_ERROR_NOT_SUPPORTED ((VL53L0X_Error)-5)
+#define VL53L0X_ERROR_NOT_SUPPORTED ((VL53L0X_Error) - 5)
 /*!< Function is not supported in current mode or configuration */
-#define VL53L0X_ERROR_RANGE_ERROR ((VL53L0X_Error)-6)
+#define VL53L0X_ERROR_RANGE_ERROR ((VL53L0X_Error) - 6)
 /*!< Device report a ranging error interrupt status */
-#define VL53L0X_ERROR_TIME_OUT ((VL53L0X_Error)-7)
+#define VL53L0X_ERROR_TIME_OUT ((VL53L0X_Error) - 7)
 /*!< Aborted due to time out */
-#define VL53L0X_ERROR_MODE_NOT_SUPPORTED ((VL53L0X_Error)-8)
+#define VL53L0X_ERROR_MODE_NOT_SUPPORTED ((VL53L0X_Error) - 8)
 /*!< Asked mode is not supported by the device */
-#define VL53L0X_ERROR_BUFFER_TOO_SMALL ((VL53L0X_Error)-9)
+#define VL53L0X_ERROR_BUFFER_TOO_SMALL ((VL53L0X_Error) - 9)
 /*!< ... */
-#define VL53L0X_ERROR_GPIO_NOT_EXISTING ((VL53L0X_Error)-10)
+#define VL53L0X_ERROR_GPIO_NOT_EXISTING ((VL53L0X_Error) - 10)
 /*!< User tried to setup a non-existing GPIO pin */
-#define VL53L0X_ERROR_GPIO_FUNCTIONALITY_NOT_SUPPORTED ((VL53L0X_Error)-11)
+#define VL53L0X_ERROR_GPIO_FUNCTIONALITY_NOT_SUPPORTED ((VL53L0X_Error) - 11)
 /*!< unsupported GPIO functionality */
-#define VL53L0X_ERROR_INTERRUPT_NOT_CLEARED ((VL53L0X_Error)-12)
+#define VL53L0X_ERROR_INTERRUPT_NOT_CLEARED ((VL53L0X_Error) - 12)
 /*!< Error during interrupt clear */
-#define VL53L0X_ERROR_CONTROL_INTERFACE ((VL53L0X_Error)-20)
+#define VL53L0X_ERROR_CONTROL_INTERFACE ((VL53L0X_Error) - 20)
 /*!< error reported from IO functions */
-#define VL53L0X_ERROR_INVALID_COMMAND ((VL53L0X_Error)-30)
+#define VL53L0X_ERROR_INVALID_COMMAND ((VL53L0X_Error) - 30)
 /*!< The command is not allowed in the current device state
  *	(power down) */
-#define VL53L0X_ERROR_DIVISION_BY_ZERO ((VL53L0X_Error)-40)
+#define VL53L0X_ERROR_DIVISION_BY_ZERO ((VL53L0X_Error) - 40)
 /*!< In the function a division by zero occurs */
-#define VL53L0X_ERROR_REF_SPAD_INIT ((VL53L0X_Error)-50)
+#define VL53L0X_ERROR_REF_SPAD_INIT ((VL53L0X_Error) - 50)
 /*!< Error during reference SPAD initialization */
-#define VL53L0X_ERROR_NOT_IMPLEMENTED ((VL53L0X_Error)-99)
+#define VL53L0X_ERROR_NOT_IMPLEMENTED ((VL53L0X_Error) - 99)
 /*!< Tells requested functionality has not been implemented yet or
  * not compatible with the device */
 /** @} VL53L0X_define_Error_group */

--- a/src/vl53l0x_i2c_platform.h
+++ b/src/vl53l0x_i2c_platform.h
@@ -3,19 +3,19 @@
 
 // initialize I2C
 VL53L0X_Error VL53L0X_i2c_init(TwoWire *i2c);
-VL53L0X_Error VL53L0X_write_multi(uint8_t deviceAddress, uint8_t index, uint8_t *pdata,
-                                  uint32_t count, TwoWire *i2c);
-VL53L0X_Error VL53L0X_read_multi(uint8_t deviceAddress, uint8_t index, uint8_t *pdata,
-                                 uint32_t count, TwoWire *i2c);
-VL53L0X_Error VL53L0X_write_byte(uint8_t deviceAddress, uint8_t index, uint8_t data,
-                                 TwoWire *i2c);
-VL53L0X_Error VL53L0X_write_word(uint8_t deviceAddress, uint8_t index, uint16_t data,
-                                 TwoWire *i2c);
-VL53L0X_Error VL53L0X_write_dword(uint8_t deviceAddress, uint8_t index, uint32_t data,
-                                  TwoWire *i2c);
-VL53L0X_Error VL53L0X_read_byte(uint8_t deviceAddress, uint8_t index, uint8_t *data,
-                                TwoWire *i2c);
-VL53L0X_Error VL53L0X_read_word(uint8_t deviceAddress, uint8_t index, uint16_t *data,
-                                TwoWire *i2c);
-VL53L0X_Error VL53L0X_read_dword(uint8_t deviceAddress, uint8_t index, uint32_t *data,
-                                 TwoWire *i2c);
+VL53L0X_Error VL53L0X_write_multi(uint8_t deviceAddress, uint8_t index,
+                                  uint8_t *pdata, uint32_t count, TwoWire *i2c);
+VL53L0X_Error VL53L0X_read_multi(uint8_t deviceAddress, uint8_t index,
+                                 uint8_t *pdata, uint32_t count, TwoWire *i2c);
+VL53L0X_Error VL53L0X_write_byte(uint8_t deviceAddress, uint8_t index,
+                                 uint8_t data, TwoWire *i2c);
+VL53L0X_Error VL53L0X_write_word(uint8_t deviceAddress, uint8_t index,
+                                 uint16_t data, TwoWire *i2c);
+VL53L0X_Error VL53L0X_write_dword(uint8_t deviceAddress, uint8_t index,
+                                  uint32_t data, TwoWire *i2c);
+VL53L0X_Error VL53L0X_read_byte(uint8_t deviceAddress, uint8_t index,
+                                uint8_t *data, TwoWire *i2c);
+VL53L0X_Error VL53L0X_read_word(uint8_t deviceAddress, uint8_t index,
+                                uint16_t *data, TwoWire *i2c);
+VL53L0X_Error VL53L0X_read_dword(uint8_t deviceAddress, uint8_t index,
+                                 uint32_t *data, TwoWire *i2c);

--- a/src/vl53l0x_i2c_platform.h
+++ b/src/vl53l0x_i2c_platform.h
@@ -2,20 +2,20 @@
 #include "Wire.h"
 
 // initialize I2C
-int VL53L0X_i2c_init(TwoWire *i2c);
-int VL53L0X_write_multi(uint8_t deviceAddress, uint8_t index, uint8_t *pdata,
-                        uint32_t count, TwoWire *i2c);
-int VL53L0X_read_multi(uint8_t deviceAddress, uint8_t index, uint8_t *pdata,
-                       uint32_t count, TwoWire *i2c);
-int VL53L0X_write_byte(uint8_t deviceAddress, uint8_t index, uint8_t data,
-                       TwoWire *i2c);
-int VL53L0X_write_word(uint8_t deviceAddress, uint8_t index, uint16_t data,
-                       TwoWire *i2c);
-int VL53L0X_write_dword(uint8_t deviceAddress, uint8_t index, uint32_t data,
-                        TwoWire *i2c);
-int VL53L0X_read_byte(uint8_t deviceAddress, uint8_t index, uint8_t *data,
-                      TwoWire *i2c);
-int VL53L0X_read_word(uint8_t deviceAddress, uint8_t index, uint16_t *data,
-                      TwoWire *i2c);
-int VL53L0X_read_dword(uint8_t deviceAddress, uint8_t index, uint32_t *data,
-                       TwoWire *i2c);
+VL53L0X_Error VL53L0X_i2c_init(TwoWire *i2c);
+VL53L0X_Error VL53L0X_write_multi(uint8_t deviceAddress, uint8_t index, uint8_t *pdata,
+                                  uint32_t count, TwoWire *i2c);
+VL53L0X_Error VL53L0X_read_multi(uint8_t deviceAddress, uint8_t index, uint8_t *pdata,
+                                 uint32_t count, TwoWire *i2c);
+VL53L0X_Error VL53L0X_write_byte(uint8_t deviceAddress, uint8_t index, uint8_t data,
+                                 TwoWire *i2c);
+VL53L0X_Error VL53L0X_write_word(uint8_t deviceAddress, uint8_t index, uint16_t data,
+                                 TwoWire *i2c);
+VL53L0X_Error VL53L0X_write_dword(uint8_t deviceAddress, uint8_t index, uint32_t data,
+                                  TwoWire *i2c);
+VL53L0X_Error VL53L0X_read_byte(uint8_t deviceAddress, uint8_t index, uint8_t *data,
+                                TwoWire *i2c);
+VL53L0X_Error VL53L0X_read_word(uint8_t deviceAddress, uint8_t index, uint16_t *data,
+                                TwoWire *i2c);
+VL53L0X_Error VL53L0X_read_dword(uint8_t deviceAddress, uint8_t index, uint32_t *data,
+                                 TwoWire *i2c);

--- a/src/vl53l0x_platform_log.h
+++ b/src/vl53l0x_platform_log.h
@@ -43,7 +43,7 @@ extern "C" {
  * @brief platform log function definition
  */
 
-//#define VL53L0X_LOG_ENABLE 0
+// #define VL53L0X_LOG_ENABLE 0
 
 enum {
   TRACE_LEVEL_NONE,
@@ -100,7 +100,7 @@ void trace_print_module_function(uint32_t module, uint32_t level,
                               __FUNCTION__, (int)status, ##__VA_ARGS__)
 
 // __func__ is gcc only
-//#define VL53L0X_ErrLog( fmt, ...)  fprintf(stderr, "VL53L0X_ErrLog %s" fmt
+// #define VL53L0X_ErrLog( fmt, ...)  fprintf(stderr, "VL53L0X_ErrLog %s" fmt
 //"\n", __func__, ##__VA_ARGS__)
 
 #else /* VL53L0X_LOG_ENABLE no logging */


### PR DESCRIPTION
On my ESP32 WROOM DevKit v1, the initial HW Reset does not work, and if the device has a non-default id (e.g. 0x30), startup fails (actually after 25 seconds it may work as the chip gets reset). Had to watch this on my scope to figure out what was not working.

This gets resolved in setup() with a simple setting of the shutdown pin to output using pinMode.

Note, other examples that try to reset the sensor correctly set the output pin mode of the shutdown pin.