### PR TITLE
Fix reset (shutdown pin) - configuring as output pin mode

### DIFF
--- a/examples/vl53l0x_Interrupt/vl53l0x_Interrupt.ino
+++ b/examples/vl53l0x_Interrupt/vl53l0x_Interrupt.ino
@@ -4,6 +4,14 @@ const byte VL53LOX_ShutdownPin = 9;
 volatile byte VL53LOX_State = LOW;
 Adafruit_VL53L0X lox = Adafruit_VL53L0X();
 
+void VL53LOXISR() {
+  // Read if we are high or low
+  VL53LOX_State = digitalRead(VL53LOX_InterruptPin);
+  // set the built in LED to reflect in range on for Out of range off for in
+  // range
+  digitalWrite(LED_BUILTIN, VL53LOX_State);
+}
+
 void setup() {
   Serial.begin(115200);
 
@@ -13,6 +21,7 @@ void setup() {
   }
   Serial.println(F("VL53L0X API Interrupt Ranging example\n\n"));
 
+  pinMode(VL53LOX_ShutdownPin, OUTPUT);
   pinMode(VL53LOX_ShutdownPin, INPUT_PULLUP);
   pinMode(VL53LOX_InterruptPin, INPUT_PULLUP);
   attachInterrupt(digitalPinToInterrupt(VL53LOX_InterruptPin), VL53LOXISR,
@@ -58,14 +67,6 @@ void setup() {
 
   Serial.println("StartMeasurement... ");
   lox.startMeasurement();
-}
-
-void VL53LOXISR() {
-  // Read if we are high or low
-  VL53LOX_State = digitalRead(VL53LOX_InterruptPin);
-  // set the built in LED to reflect in range on for Out of range off for in
-  // range
-  digitalWrite(LED_BUILTIN, VL53LOX_State);
 }
 
 void loop() {

--- a/src/platform/src/vl53l0x_i2c_comms.cpp
+++ b/src/platform/src/vl53l0x_i2c_comms.cpp
@@ -1,7 +1,7 @@
 #include "../../vl53l0x_def.h"
 #include "../../vl53l0x_i2c_platform.h"
 
-//#define I2C_DEBUG
+// #define I2C_DEBUG
 
 int VL53L0X_i2c_init(TwoWire *i2c) {
   i2c->begin();

--- a/src/vl53l0x_def.h
+++ b/src/vl53l0x_def.h
@@ -124,44 +124,44 @@ typedef struct {
 typedef int8_t VL53L0X_Error;
 
 #define VL53L0X_ERROR_NONE ((VL53L0X_Error)0)
-#define VL53L0X_ERROR_CALIBRATION_WARNING ((VL53L0X_Error)-1)
+#define VL53L0X_ERROR_CALIBRATION_WARNING ((VL53L0X_Error) - 1)
 /*!< Warning invalid calibration data may be in used
         \a	VL53L0X_InitData()
         \a VL53L0X_GetOffsetCalibrationData
         \a VL53L0X_SetOffsetCalibrationData */
-#define VL53L0X_ERROR_MIN_CLIPPED ((VL53L0X_Error)-2)
+#define VL53L0X_ERROR_MIN_CLIPPED ((VL53L0X_Error) - 2)
 /*!< Warning parameter passed was clipped to min before to be applied */
 
-#define VL53L0X_ERROR_UNDEFINED ((VL53L0X_Error)-3)
+#define VL53L0X_ERROR_UNDEFINED ((VL53L0X_Error) - 3)
 /*!< Unqualified error */
-#define VL53L0X_ERROR_INVALID_PARAMS ((VL53L0X_Error)-4)
+#define VL53L0X_ERROR_INVALID_PARAMS ((VL53L0X_Error) - 4)
 /*!< Parameter passed is invalid or out of range */
-#define VL53L0X_ERROR_NOT_SUPPORTED ((VL53L0X_Error)-5)
+#define VL53L0X_ERROR_NOT_SUPPORTED ((VL53L0X_Error) - 5)
 /*!< Function is not supported in current mode or configuration */
-#define VL53L0X_ERROR_RANGE_ERROR ((VL53L0X_Error)-6)
+#define VL53L0X_ERROR_RANGE_ERROR ((VL53L0X_Error) - 6)
 /*!< Device report a ranging error interrupt status */
-#define VL53L0X_ERROR_TIME_OUT ((VL53L0X_Error)-7)
+#define VL53L0X_ERROR_TIME_OUT ((VL53L0X_Error) - 7)
 /*!< Aborted due to time out */
-#define VL53L0X_ERROR_MODE_NOT_SUPPORTED ((VL53L0X_Error)-8)
+#define VL53L0X_ERROR_MODE_NOT_SUPPORTED ((VL53L0X_Error) - 8)
 /*!< Asked mode is not supported by the device */
-#define VL53L0X_ERROR_BUFFER_TOO_SMALL ((VL53L0X_Error)-9)
+#define VL53L0X_ERROR_BUFFER_TOO_SMALL ((VL53L0X_Error) - 9)
 /*!< ... */
-#define VL53L0X_ERROR_GPIO_NOT_EXISTING ((VL53L0X_Error)-10)
+#define VL53L0X_ERROR_GPIO_NOT_EXISTING ((VL53L0X_Error) - 10)
 /*!< User tried to setup a non-existing GPIO pin */
-#define VL53L0X_ERROR_GPIO_FUNCTIONALITY_NOT_SUPPORTED ((VL53L0X_Error)-11)
+#define VL53L0X_ERROR_GPIO_FUNCTIONALITY_NOT_SUPPORTED ((VL53L0X_Error) - 11)
 /*!< unsupported GPIO functionality */
-#define VL53L0X_ERROR_INTERRUPT_NOT_CLEARED ((VL53L0X_Error)-12)
+#define VL53L0X_ERROR_INTERRUPT_NOT_CLEARED ((VL53L0X_Error) - 12)
 /*!< Error during interrupt clear */
-#define VL53L0X_ERROR_CONTROL_INTERFACE ((VL53L0X_Error)-20)
+#define VL53L0X_ERROR_CONTROL_INTERFACE ((VL53L0X_Error) - 20)
 /*!< error reported from IO functions */
-#define VL53L0X_ERROR_INVALID_COMMAND ((VL53L0X_Error)-30)
+#define VL53L0X_ERROR_INVALID_COMMAND ((VL53L0X_Error) - 30)
 /*!< The command is not allowed in the current device state
  *	(power down) */
-#define VL53L0X_ERROR_DIVISION_BY_ZERO ((VL53L0X_Error)-40)
+#define VL53L0X_ERROR_DIVISION_BY_ZERO ((VL53L0X_Error) - 40)
 /*!< In the function a division by zero occurs */
-#define VL53L0X_ERROR_REF_SPAD_INIT ((VL53L0X_Error)-50)
+#define VL53L0X_ERROR_REF_SPAD_INIT ((VL53L0X_Error) - 50)
 /*!< Error during reference SPAD initialization */
-#define VL53L0X_ERROR_NOT_IMPLEMENTED ((VL53L0X_Error)-99)
+#define VL53L0X_ERROR_NOT_IMPLEMENTED ((VL53L0X_Error) - 99)
 /*!< Tells requested functionality has not been implemented yet or
  * not compatible with the device */
 /** @} VL53L0X_define_Error_group */

--- a/src/vl53l0x_platform_log.h
+++ b/src/vl53l0x_platform_log.h
@@ -43,7 +43,7 @@ extern "C" {
  * @brief platform log function definition
  */
 
-//#define VL53L0X_LOG_ENABLE 0
+// #define VL53L0X_LOG_ENABLE 0
 
 enum {
   TRACE_LEVEL_NONE,
@@ -100,7 +100,7 @@ void trace_print_module_function(uint32_t module, uint32_t level,
                               __FUNCTION__, (int)status, ##__VA_ARGS__)
 
 // __func__ is gcc only
-//#define VL53L0X_ErrLog( fmt, ...)  fprintf(stderr, "VL53L0X_ErrLog %s" fmt
+// #define VL53L0X_ErrLog( fmt, ...)  fprintf(stderr, "VL53L0X_ErrLog %s" fmt
 //"\n", __func__, ##__VA_ARGS__)
 
 #else /* VL53L0X_LOG_ENABLE no logging */


### PR DESCRIPTION
On my ESP32 WROOM DevKit v1, the initial HW Reset does not work, and if the device has a non-default id (e.g. 0x30), startup fails (actually after 25 seconds it may work as the chip gets reset). Had to watch this on my scope to figure out what was not working.

This gets resolved in setup() with a simple setting of the shutdown pin to output using pinMode.

Note, other examples that try to reset the sensor correctly set the output pin mode of the shutdown pin.

Other changes:
- I found out the hard way some of the files needed reformatting with clang-format. This is part of this commit, otherwise the CI will fail
- I moved the ISP implementation to a point before it was referenced, to keep the example simple and make it easier to reuse