### PR TITLE
Implement getAddress to return the device current I2C address

### DIFF
--- a/src/Adafruit_VL53L0X.cpp
+++ b/src/Adafruit_VL53L0X.cpp
@@ -208,6 +208,17 @@ boolean Adafruit_VL53L0X::setAddress(uint8_t newAddr) {
 
 /**************************************************************************/
 /*!
+    @brief  Get the I2C address of the sensor
+    @returns The address the sensor is actually associated.
+*/
+/**************************************************************************/
+uint8_t Adafruit_VL53L0X::getAddress(void){
+  uint8_t currentAddress = pMyDevice->I2cDevAddr;
+  return (currentAddress);
+}
+
+/**************************************************************************/
+/*!
     @brief  Configure the sensor for one of the ways the example ST
     sketches configure the sensors for different usages.
     @param  vl_config Which configureation you are trying to configure for

--- a/src/Adafruit_VL53L0X.cpp
+++ b/src/Adafruit_VL53L0X.cpp
@@ -212,7 +212,7 @@ boolean Adafruit_VL53L0X::setAddress(uint8_t newAddr) {
     @returns The address the sensor is actually associated.
 */
 /**************************************************************************/
-uint8_t Adafruit_VL53L0X::getAddress(void){
+uint8_t Adafruit_VL53L0X::getAddress(void) {
   uint8_t currentAddress = pMyDevice->I2cDevAddr;
   return (currentAddress);
 }

--- a/src/Adafruit_VL53L0X.h
+++ b/src/Adafruit_VL53L0X.h
@@ -54,7 +54,7 @@ class Adafruit_VL53L0X {
                 VL53L0X_Sense_config_t vl_config = VL53L0X_SENSE_DEFAULT);
   boolean setAddress(uint8_t newAddr);
 
-  // uint8_t getAddress(void); // not currently implemented
+  uint8_t getAddress(void);
 
   /**************************************************************************/
   /*!


### PR DESCRIPTION
The change consist on the implementation of the getAddress function, that was already commented on the **Adafruit_VL53L0X.h** file as _currently not implemented_. The function is simple and concise, and use the **I2cDevAddr** of **pMyDevice** object, that already existed.
